### PR TITLE
Travis CI: Lint Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ env:
         - GROUP=2
         - GROUP=3
     allow_failures:
-        - python: 3.9"
+        - python: 3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-dist: trusty
+dist: focal
 
 language: python
 python:
   - "2.7"
+  - "3.9"
+
+jobs:
+  allow_failures:
+    - python: 3.9"
 
 addons:
   apt:
@@ -35,10 +40,11 @@ before_install:
   - rm bazel_0.23.2-linux-x86_64.deb
 
     # Install App Engine test dependency
-  - pip install Pillow
+  - pip install flake8 Pillow
 
 # Shard test execution to avoid Bazel failing with OOM/OOS on the Travis VM.
 # Without sharding, failure occurred after ~25 tests.
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: "./run_tests.sh $GROUP $TOTAL_GROUPS"
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - "2.7"
   - "3.5"
 
+jobs:
+  allow_failures:
+    - python: "3.5"
+
 addons:
   apt:
     sources:
@@ -51,5 +55,3 @@ env:
         - GROUP=1
         - GROUP=2
         - GROUP=3
-        allow_failures:
-            - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: focal
+dist: xenial
 
 language: python
 python:
   - "2.7"
-  - "3.9"
+  - "3.5"
 
 addons:
   apt:
@@ -13,8 +13,8 @@ addons:
       - wget
       - pkg-config
 
-# virtualenv:
-#  system_site_packages: true
+virtualenv:
+  system_site_packages: true
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 
 language: python
@@ -50,5 +51,5 @@ env:
         - GROUP=1
         - GROUP=2
         - GROUP=3
-    allow_failures:
-        - python: 3.5"
+        allow_failures:
+            - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
   - "2.7"
   - "3.9"
 
-jobs:
-  allow_failures:
-    - python: 3.9"
-
 addons:
   apt:
     sources:
@@ -17,8 +13,8 @@ addons:
       - wget
       - pkg-config
 
-virtualenv:
-  system_site_packages: true
+# virtualenv:
+#  system_site_packages: true
 
 branches:
   only:
@@ -49,8 +45,10 @@ script: "./run_tests.sh $GROUP $TOTAL_GROUPS"
 env:
     global:
         - TOTAL_GROUPS=4
-    matrix:
+    jobs:
         - GROUP=0
         - GROUP=1
         - GROUP=2
         - GROUP=3
+    allow_failures:
+        - python: 3.9"


### PR DESCRIPTION
Python 2 passes the targeted flake8 tests without modification.
Python 3 is run in `allow_failures` mode and shows the initial quick fixes required to start adding Python 3 compatibility.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.